### PR TITLE
Moving schema validation to queryFn and using isValidSchema

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reusableflows",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "A wrapper for your useQuery calls to centralize them and type them all",
   "main": "index.tsx",
   "keywords": [


### PR DESCRIPTION
A lot of code should be reused.

The declaration of input and output is nearly the same. Also the execution of  query or mutation funciton are the same.

